### PR TITLE
Add json view to entire schema collection

### DIFF
--- a/app/controllers/schemas/schema.js
+++ b/app/controllers/schemas/schema.js
@@ -1,11 +1,9 @@
 import Ember from 'ember';
 import Schema from 'ember-json-schema-document/models/schema';
-import { storageFor } from 'ember-local-storage';
 
 export default Ember.Controller.extend({
   currentTab: 'output',
 
-  schemaLibrary: storageFor('schemaLibrary'),
   initialSchema: null,    // Set in setupController, used to seed jsonEditor
   currentSchema: null,    // Schema bound to jsonEditor
   jsonDocument: { security_controls: {} },     // Default json document seed
@@ -14,10 +12,6 @@ export default Ember.Controller.extend({
   renderProperties() {
     let schema = new Schema(this.get('model.schema'));
     let schemaDocument = schema.buildDocument();
-
-    // if(this.get('jsonDocument')) {
-    //   schemaDocument.load(this.get('jsonDocument') || {});
-    // }
 
     this.setProperties({ schema, schemaDocument });
   },

--- a/app/router.js
+++ b/app/router.js
@@ -7,6 +7,7 @@ var Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('schemas', {}, function() {
+    this.route('json_graph');
     this.route('schema', { path: ':schema_id'});
   });
 });

--- a/app/routes/schemas/json-graph.js
+++ b/app/routes/schemas/json-graph.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+import { buildImportFromSchemas } from 'schema-builder/utils/build-import-json';
+
+export default Ember.Route.extend({
+  model() {
+    return this.modelFor('schemas');
+  },
+
+  setupController(controller, model) {
+    let importJSON = buildImportFromSchemas(model);
+    controller.set('importJSON', importJSON);
+  }
+});

--- a/app/templates/schemas.hbs
+++ b/app/templates/schemas.hbs
@@ -2,7 +2,7 @@
   <div class="col-xs-2 schema-index">
     <div class="panel panel-default">
       <div class="panel-heading">
-        Schemas
+        Schemas ({{link-to 'json' 'schemas.json_graph'}})
       </div>
       <ul class="list-group">
         {{#each model as |schema|}}

--- a/app/templates/schemas/json-graph.hbs
+++ b/app/templates/schemas/json-graph.hbs
@@ -1,0 +1,3 @@
+<div class="json-editor">
+  {{json-editor json=importJSON mode="text"}}
+</div>

--- a/app/templates/schemas/schema.hbs
+++ b/app/templates/schemas/schema.hbs
@@ -60,7 +60,8 @@
           {{/if}}
         {{/each-property}}
       {{/if}}
-    {{else}}
+    {{/if}}
+    {{#if (eq currentTab 'document')}}
       <div class="json-editor">
         {{json-editor json=documentJSON mode="view"}}
       </div>

--- a/app/utils/build-import-json.js
+++ b/app/utils/build-import-json.js
@@ -1,0 +1,63 @@
+import Ember from 'ember';
+
+export function buildImportFromSchemas(schemas) {
+  let output = {};
+
+  output.predisposing_conditions = [];
+  output.security_controls = [];
+
+  schemas.forEach((schema) => {
+    let schemaOutput = buildImportFromSchema(schema.get('schema'));
+    output.predisposing_conditions = output.predisposing_conditions.concat(schemaOutput.predisposing_conditions);
+    output.security_controls = output.security_controls.concat(schemaOutput.security_controls);
+  });
+
+  return output;
+}
+
+export function buildImportFromSchema(schema) {
+  let output = {};
+  output.predisposing_conditions = [];
+  output.security_controls = [];
+
+  if(schema.properties.predisposing_conditions) {
+    Ember.keys(schema.properties.predisposing_conditions.properties).forEach((pdcHandle) => {
+      let pdc = schema.properties.predisposing_conditions.properties[pdcHandle];
+      output.predisposing_conditions.push({
+        handle: pdcHandle,
+        name: pdc.title,
+        description: '--',
+        pervasiveness: 0
+      });
+    });
+  }
+
+  Ember.keys(schema.properties.security_controls.properties).forEach((scHandle) => {
+    let sc = schema.properties.security_controls.properties[scHandle];
+    let status = 'unimplemented';
+
+    if(sc.type !== "object") {
+      return
+    }
+
+    let implementedProperty = Ember.getWithDefault(sc, 'properties.implemented', false);
+
+    if(!implementedProperty) {
+      return;
+    }
+
+    if(implementedProperty.default == true) {
+      status = 'implemented';
+    }
+
+    let name = sc.title || implementedProperty.title;
+
+    output.security_controls.push({
+      handle: scHandle,
+      description: '--',
+      status, name
+    });
+  });
+
+  return output;
+}


### PR DESCRIPTION
This PR adds a little `JSON` button to the schemas sidebar.  Clicking this link will take you to a full rendering of all risk model components currently viewable across all schemas currently loaded in memory.   The goal of this is to allow simple "exporting" of controls into something like ochoinco.
