### PR TITLE
Prefix version in downloaded schema filename with 'v'

### DIFF
--- a/app/models/schema.js
+++ b/app/models/schema.js
@@ -1,11 +1,13 @@
 import DS from 'ember-data';
+import Ember from 'ember';
+
 const FILE_TYPE = 'application/json;charset=utf-8';
 
 export default DS.Model.extend({
   schema: DS.attr(),
   fileName: Ember.computed('schema.id', function() {
     let segments = this.get('schema.id').split('/').reverse();
-    return `${segments[1]}_${segments[0]}.json`;
+    return `${segments[1]}_v${segments[0]}.json`;
   }),
 
   export() {


### PR DESCRIPTION
This appears to better match the schema filenames that are checked in to gridiron.

cc @sandersonet